### PR TITLE
Add jaxb-api as a dependency since it's not available by default in Java 9+.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,7 @@
-(defproject lein-gorilla "0.4.0"
+(defproject lein-gorilla "0.5.0-SNAPSHOT"
   :description "A Leiningen plugin for the Gorilla REPL."
   :url "https://github.com/JonyEpsilon/lein-gorilla"
   :license {:name "MIT"}
-  :dependencies [[gorilla-repl "0.4.0"]]
+  :dependencies [[gorilla-repl "0.4.0"]
+                 [javax.xml.bind/jaxb-api "2.3.0"]]
   :eval-in-leiningen true)


### PR DESCRIPTION

Without it, `lein gorilla` fails with following exception:
```
ojure.lang.Compiler$CompilerException: java.lang.ClassNotFoundException:
javax.xml.bind.DatatypeConverter, compiling:(org/httpkit/server.clj:1:1)
 at clojure.lang.Compiler.load (Compiler.java:7391)
```